### PR TITLE
Add Invoice Due at on admin Invoice Overview

### DIFF
--- a/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
+++ b/src/modules/Invoice/html_admin/mod_invoice_index.html.twig
@@ -210,6 +210,7 @@
                             <th>{{ 'Name'|trans }}</th>
                             <th class="text-center">{{ 'Amount'|trans }}</th>
                             <th class="text-center">{{ 'Issued at'|trans }}</th>
+                            <th class="text-center">{{ 'Due at'|trans }}</th>
                             <th class="text-center">{{ 'Paid at'|trans }}</th>
                             <th>{{ 'Status'|trans }}</th>
                             <th class="w-1"></th>
@@ -235,7 +236,8 @@
                             </td>
                             <td class="text-center">{{ mf.currency_format(invoice.total, invoice.currency) }}</td>
                             <td class="text-center">{{ invoice.created_at|date('Y-m-d') }}</td>
-                            <td class="text-center">{% if invoice.paid_at %}{{ invoice.paid_at|date('Y-m-d') }}{% else %}-{% endif %}</td>
+                            <td class="text-center">{{ invoice.due_at|date('Y-m-d') }}</td>
+                            <td class="text-center">{% if invoice.paid_at %}{{ invoice.paid_at|date('Y-m-d')}}{% else %}-{% endif %}</td>
                             <td>
                                 {% if invoice.status == 'paid' %}
                                     <span class="badge bg-success me-1"></span>


### PR DESCRIPTION
Added column to show invoice due at in admin invoice overview - #1976

This is tested on my staging site and works fine. However I have noticed whilst testing the the invoice filters do not seem to function correctly.

Also could you confirm if the date format being used is correct, or if this needs updating to use  

date('Y-m-d')
format_date
format_datetime

![image](https://github.com/gilesytheking/FOSSBilling/assets/15634270/77af2d29-5b84-4aaf-b785-d6f45ba53c68)
